### PR TITLE
Make optional the "gclone sa file" message

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -825,7 +825,7 @@ func (f *Fs) changeSvc(ctx context.Context) {
 		}
 	}
 
-	fmt.Println("gclone sa file:", opt.ServiceAccountFile)
+	fs.Infof("Using sa file", opt.ServiceAccountFile)
 }
 //------------------------------------------------------------
 


### PR DESCRIPTION
The message now uses the rclone log system and now it is only shown if the -v flag is used (useful with --log-file)
The output message now is something like:
2022-04-18 15:50:29 INFO  : Using sa file: C:\gclone\accounts\file.json